### PR TITLE
new README using the devkit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <h1 align="center">
   blindnet devkit<br />
-  Java SDK
+  Java Server SDK
 </h1>
 
 <p align=center><img src="https://user-images.githubusercontent.com/7578400/163277439-edd00509-1d1b-4565-a0d3-49057ebeb92a.png#gh-light-mode-only" height="80" /></p>
 <p align=center><img src="https://user-images.githubusercontent.com/7578400/163549893-117bbd70-b81a-47fd-8e1f-844911e48d68.png#gh-dark-mode-only" height="80" /></p>
 
 <p align="center">
-  <strong>Java SDK for authentication tokens generation and user management</strong>
+  <strong>Java Server SDK for authentication tokens generation and user management</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  blindnet devkit<br />
+  blindnet encryption engine<br />
   Java Server SDK
 </h1>
 
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://blindnet.dev/docs">Documentation</a>
+  <a href="https://blindnet.dev/docs/encryption">Documentation</a>
   &nbsp;•&nbsp;
   <a href="https://github.com/blindnet-io/sdk-php-server/issues">Submit an Issue</a>
   &nbsp;•&nbsp;
@@ -26,14 +26,14 @@
 
 ## About
 
-This is the Java [server-side SDK](https://blindnet.dev/docs/glossary#server-side-sdk) component of [blindnet devkit][devkit] allowing you to:
+This is the Java [server-side SDK](https://blindnet.dev/docs/references/glossary#server-side-sdk) component of the blindnet encryption engine allowing you to:
 
-- Generate [authentication tokens](https://blindnet.dev/docs/glossary#authentication-token) to allow users to access blindnet.
+- Generate [authentication tokens](https://blindnet.dev/docs/references/glossary#authentication-token) to allow users to access blindnet.
 - Manage application users and data on blindnet.
 
 ## Get Started
 
-:rocket: Check out our [Quick Start Guide](https://blindnet.dev/docs/quickstart) to get started in a snap.
+:rocket: Check out our [Quick Start Guide](https://blindnet.dev/docs/encryption/quickstart) to get started in a snap.
 
 ## Installation
 
@@ -43,11 +43,6 @@ Use [{package manager or plateform}][install-tool] to install {project's name}:
 ```bash
 {install-command}
 ```
-
-<!-- FIXME: add API Reference
-## Usage
-📑 The API reference of blindnet devkit Node.js Server SDK is available on [blindnet.dev](https://docs.blindnet.io/docs/api_reference/server/node.js/latest).
--->
 
 ## Contributing
 
@@ -68,7 +63,7 @@ Stay up to date with new releases and projects, learn more about how to protect 
 
 ## License
 
-The blindnet devkit sdk-java-server is available under [MIT][license] (and [here](https://github.com/blindnet-io/openness-framework/blob/main/docs/decision-records/DR-0001-oss-license.md) is why).
+The blindnet encryption engine sdk-java-server is available under [MIT][license] (and [here](https://github.com/blindnet-io/openness-framework/blob/main/docs/decision-records/DR-0001-oss-license.md) is why).
 
 <!-- project's URLs -->
 
@@ -80,7 +75,6 @@ The blindnet devkit sdk-java-server is available under [MIT][license] (and [here
 [composer]: https://getcomposer.org/
 
 <!-- common URLs -->
-[devkit]: https://github.com/blindnet-io/blindnet.dev
 [openness]: https://github.com/blindnet-io/openness-framework
 [product]: https://github.com/blindnet-io/product-management
 [request]: https://github.com/blindnet-io/devrel-management/issues/new?assignees=noelmace&labels=request%2Ctriage&template=request.yml&title=%5BRequest%5D%3A+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-# blindnet-sdk-java-server
+<h1 align="center">
+  blindnet devkit<br />
+  Java SDK
+</h1>
+
+<p align=center><img src="https://user-images.githubusercontent.com/7578400/163277439-edd00509-1d1b-4565-a0d3-49057ebeb92a.png#gh-light-mode-only" height="80" /></p>
+<p align=center><img src="https://user-images.githubusercontent.com/7578400/163549893-117bbd70-b81a-47fd-8e1f-844911e48d68.png#gh-dark-mode-only" height="80" /></p>
+
+<p align="center">
+  <strong>Java SDK for authentication tokens generation and user management</strong>
+</p>
+
+<p align="center">
+  <a href="https://blindnet.dev"><strong>blindnet.dev</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://blindnet.dev/docs">Documentation</a>
+  &nbsp;•&nbsp;
+  <a href="https://github.com/blindnet-io/sdk-php-server/issues">Submit an Issue</a>
+  &nbsp;•&nbsp;
+  <a href="https://join.slack.com/t/blindnet/shared_invite/zt-1arqlhqt3-A8dPYXLbrnqz1ZKsz6ItOg">Online Chat</a>
+  <br>
+  <br>
+</p>
+
+## About
+
+This is the Java [server-side SDK](https://blindnet.dev/docs/extra/glossary#server-side-sdk) component of [blindnet devkit][devkit] allowing you to:
+
+- Generate [authentication tokens](https://blindnet.dev/docs/extra/glossary#authentication-token) to allow users to access blindnet.
+- Manage application users and data on blindnet.
+
+## Get Started
+
+:rocket: Check out our [Quick Start Guide](https://blindnet.dev/docs/quickstart) to get started in a snap.
+
+## Installation
+
+<!-- FIXME: add install steps -->
+Use [{package manager or plateform}][install-tool] to install {project's name}:
+
+```bash
+{install-command}
+```
+
+<!-- FIXME: add API Reference
+## Usage
+📑 The API reference of blindnet devkit Node.js Server SDK is available on [blindnet.dev](https://docs.blindnet.io/docs/api_reference/server/node.js/latest).
+-->
+
+## Contributing
+
+Contributions of all kinds are always welcome!
+
+If you see a bug or room for improvement in this project in particular, please [open an issue][new-issue] or directly [fork this repository][fork] to submit a Pull Request.
+
+If you have any broader questions or suggestions, just open a simple informal [DevRel Request][request], and we'll make sure to quickly find the best solution for you.
+
+## Community
+
+> All community participation is subject to blindnet’s [Code of Conduct][coc].
+Stay up to date with new releases and projects, learn more about how to protect your privacy and that of our users, and share projects and feedback with our team.
+
+- [Join our Slack Workspace][chat] to chat with the blindnet community and team
+- Follow us on [Twitter][twitter] to stay up to date with the latest news
+- Check out our [Openness Framework][openness] and [Product Management][product] on Github to see how we operate and give us feedback.
+
+## License
+
+The blindnet devkit sdk-java-server is available under [MIT][license] (and [here](https://github.com/blindnet-io/openness-framework/blob/main/docs/decision-records/DR-0001-oss-license.md) is why).
+
+<!-- project's URLs -->
+
+[new-issue]: https://github.com/blindnet-io/sdk-java-server/issues/new/choose
+[fork]: https://github.com/blindnet-io/sdk-java-server/fork
+
+<!-- Tools -->
+
+[composer]: https://getcomposer.org/
+
+<!-- common URLs -->
+[devkit]: https://github.com/blindnet-io/blindnet.dev
+[openness]: https://github.com/blindnet-io/openness-framework
+[product]: https://github.com/blindnet-io/product-management
+[request]: https://github.com/blindnet-io/devrel-management/issues/new?assignees=noelmace&labels=request%2Ctriage&template=request.yml&title=%5BRequest%5D%3A+
+[chat]: https://join.slack.com/t/blindnet/shared_invite/zt-1arqlhqt3-A8dPYXLbrnqz1ZKsz6ItOg
+[twitter]: https://twitter.com/blindnet_io
+[docs]: https://blindnet.dev/docs
+[changelog]: CHANGELOG.md
+[license]: LICENSE
+[coc]: https://github.com/blindnet-io/openness-framework/blob/main/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 This is the Java [server-side SDK](https://blindnet.dev/docs/glossary#server-side-sdk) component of [blindnet devkit][devkit] allowing you to:
 
-- Generate [authentication tokens](https://blindnet.dev/docs/extra/glossary#authentication-token) to allow users to access blindnet.
+- Generate [authentication tokens](https://blindnet.dev/docs/glossary#authentication-token) to allow users to access blindnet.
 - Manage application users and data on blindnet.
 
 ## Get Started

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## About
 
-This is the Java [server-side SDK](https://blindnet.dev/docs/extra/glossary#server-side-sdk) component of [blindnet devkit][devkit] allowing you to:
+This is the Java [server-side SDK](https://blindnet.dev/docs/glossary#server-side-sdk) component of [blindnet devkit][devkit] allowing you to:
 
 - Generate [authentication tokens](https://blindnet.dev/docs/extra/glossary#authentication-token) to allow users to access blindnet.
 - Manage application users and data on blindnet.


### PR DESCRIPTION
New README based on the [devkit README template](https://github.com/blindnet-io/openness-framework/blob/main/OpenSource/template/devkit-README.md).

see https://github.com/blindnet-io/devrel-management/issues/9 & https://github.com/blindnet-io/openness-framework/pull/33

:warning: @blindnet-io/engineering  should still add the installation steps

API Ref can be addressed after this PR, but is a top priority.